### PR TITLE
Fix Incomplete Induction List Bug

### DIFF
--- a/src/components/induction/give.vue
+++ b/src/components/induction/give.vue
@@ -8,7 +8,7 @@
         :disabled="!!induction"
         :loading="loadingItems"
         label="Select Induction"
-        item-text="name"
+        item-text="ref"
         return-object
         outlined
       >

--- a/src/components/induction/give.vue
+++ b/src/components/induction/give.vue
@@ -9,6 +9,7 @@
         :loading="loadingItems"
         label="Select Induction"
         item-text="ref"
+        item-value="_id"
         return-object
         outlined
       >


### PR DESCRIPTION
## Description
The list of available inductions was incomplete for inductors. This was due to the render key being used for the `v-select` for selecting inductions being the`name` of the induction item, which in some cases collided (e.g. `Inductor sign-off`).

## Changes
* Changes `v-select` key to be the `ref` of the item which will be unique